### PR TITLE
Fix go tenets

### DIFF
--- a/tenets/codelingo/go/goto/.lingo
+++ b/tenets/codelingo/go/goto/.lingo
@@ -12,4 +12,4 @@ tenets:
 
       @ review.comment
       go.branch_stmt({depth: any}):
-        token: "goto"
+        tok: 73

--- a/tenets/codelingo/go/todo/.lingo
+++ b/tenets/codelingo/go/todo/.lingo
@@ -14,4 +14,4 @@ tenets:
 
       @ review.comment
       go.comment({depth: any}):
-        name: /(?i)(^|\s)TODO.*/
+        text: /(?i)(^|\s)TODO.*/


### PR DESCRIPTION
Temporary fix for https://github.com/codelingo/hub/issues/13

Goto should use string instead of enum value.