### PR TITLE
Add Readme Generator WIP

### DIFF
--- a/util/mdgen/cmd/genAll.go
+++ b/util/mdgen/cmd/genAll.go
@@ -1,0 +1,55 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// genAllCmd represents the genAll command
+var genAllCmd = &cobra.Command{
+	Use:   "genAll",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		genFactsCmd.Run(cmd, []string{"factTest.md"})
+		genLexiconCmd.Run(cmd, []string{"lexiconTest.md"})
+		genTenetsCmd.Run(cmd, []string{"tenetsTest.md"})
+
+		fmt.Println("genAll called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(genAllCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// genAllCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// genAllCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/util/mdgen/cmd/genFacts.go
+++ b/util/mdgen/cmd/genFacts.go
@@ -1,0 +1,62 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// genFactsCmd represents the genFacts command
+var genFactsCmd = &cobra.Command{
+	Use:   "genFacts",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		tmplPath := "template/fact.md"
+		outPath := args[0]
+
+		data := struct {
+			FactName string
+		}{
+			FactName: "testFact",
+		}
+
+		err := writeFile(tmplPath, outPath, data)
+		if err != nil {
+			panic(err)
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(genFactsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// genFactsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// genFactsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/util/mdgen/cmd/genLexicon.go
+++ b/util/mdgen/cmd/genLexicon.go
@@ -1,0 +1,62 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// genLexiconCmd represents the genLexicon command
+var genLexiconCmd = &cobra.Command{
+	Use:   "genLexicon",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		tmplPath := "template/lexicon.md"
+		outPath := args[0]
+
+		data := struct {
+			FactName string
+		}{
+			FactName: "textLexicon",
+		}
+
+		err := writeFile(tmplPath, outPath, data)
+		if err != nil {
+			panic(err)
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(genLexiconCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// genLexiconCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// genLexiconCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/util/mdgen/cmd/genTenets.go
+++ b/util/mdgen/cmd/genTenets.go
@@ -1,0 +1,61 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// genTenetsCmd represents the genTenets command
+var genTenetsCmd = &cobra.Command{
+	Use:   "genTenets",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		tmplPath := "template/tenet.md"
+		outPath := args[0]
+
+		data := struct {
+			FactName string
+		}{
+			FactName: "testTenet",
+		}
+
+		err := writeFile(tmplPath, outPath, data)
+		if err != nil {
+			panic(err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(genTenetsCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// genTenetsCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// genTenetsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/util/mdgen/cmd/root.go
+++ b/util/mdgen/cmd/root.go
@@ -1,0 +1,89 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "mdgen",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.mdgen.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		// Search config in home directory with name ".mdgen" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigName(".mdgen")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/util/mdgen/cmd/write.go
+++ b/util/mdgen/cmd/write.go
@@ -1,0 +1,75 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"html/template"
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/spf13/cobra"
+)
+
+// writeCmd represents the write command
+var writeCmd = &cobra.Command{
+	Use:   "write",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		data := struct {
+			FactName string
+		}{
+			FactName: "testFact",
+		}
+
+		err := writeFile(args[0], args[1], data)
+		if err != nil {
+			panic(err)
+		}
+
+	},
+}
+
+func writeFile(tmplPath, outPath string, data interface{}) error {
+
+	tmpl := template.Must(template.ParseFiles(tmplPath))
+	file, err := os.Create(outPath)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer file.Close()
+
+	return tmpl.Execute(file, data)
+}
+
+func init() {
+	rootCmd.AddCommand(writeCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// writeCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// writeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/util/mdgen/main.go
+++ b/util/mdgen/main.go
@@ -1,0 +1,21 @@
+// Copyright © 2018 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/codelingo/hub/util/mdgen/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/util/mdgen/template/fact.md
+++ b/util/mdgen/template/fact.md
@@ -1,0 +1,2 @@
+#{{.FactName}}
+### this is a generated readme for fact {{.FactName}}

--- a/util/mdgen/template/lexicon.md
+++ b/util/mdgen/template/lexicon.md
@@ -1,0 +1,2 @@
+#{{.FactName}}
+### this is a generated readme for lexicon {{.FactName}}

--- a/util/mdgen/template/tenet.md
+++ b/util/mdgen/template/tenet.md
@@ -1,0 +1,2 @@
+#{{.FactName}}
+### this is a generated readme for tenet {{.FactName}}


### PR DESCRIPTION
Add the boiler plate for the Readme generator tool. To generate test readmes run:

```bash

$ cd util/mdgen
$ go run main.go genAll
```

This will write three md files in the pwd, based off the templates under util/mdgen/template. The individual commands genFacts genTenets and genLexicon are also available.