### PR TITLE
add tenet readme generation

### DIFF
--- a/util/mdgen/dataStruct/tenets.go
+++ b/util/mdgen/dataStruct/tenets.go
@@ -1,0 +1,26 @@
+package dataStruct
+
+type HubTenets struct {
+	Owners map[string]TenetsOwner
+}
+
+type TenetsOwner struct {
+	Name    string
+	Bundles map[string]Bundle
+}
+
+type Bundle struct {
+	Name   string
+	Tenets map[string]Tenet
+}
+
+type Tenet struct {
+	Name string
+}
+
+//This is a dumb workaround for now
+type Data struct {
+	Owner  string
+	Bundle string
+	Tenet  string
+}

--- a/util/mdgen/template/tenet.md
+++ b/util/mdgen/template/tenet.md
@@ -1,2 +1,3 @@
-#{{.FactName}}
-### this is a generated readme for tenet {{.FactName}}
+#{{.Tenet}}
+### This is a generated readme for tenet {{.Tenet}}
+[Demo](https://dev.codelingo.io/playground/?repo=github.com/codelingo/hub&dir=tenets/{{.Owner}}/{{.Bundle}}/{{.Tenet}}&tenet={{.Owner}}/{{.Bundle}}/{{.Tenet}})


### PR DESCRIPTION
This will generate a README.md at the root of each tenet ie ...hub/tenets/cacophony/default/caught-generic-exceptions/README.md

example README content:
```
#caught-generic-exceptions
### This is a generated readme for tenet caught-generic-exceptions
[Demo](https://dev.codelingo.io/playground/?repo=github.com/codelingo/hub&dir=tenets/cacophony/default/caught-generic-exceptions&tenet=cacophony/default/caught-generic-exceptions)
```