### PR TITLE
Tenets/php/sql injection

### DIFF
--- a/tenets/codelingo/php/sql-concats/.lingo
+++ b/tenets/codelingo/php/sql-concats/.lingo
@@ -6,13 +6,14 @@ tenets:
         comments: SQL query strings shouldnt be concatenated as these are susceptible to SQL injection
     query: |
       import codelingo/ast/php
-      any_of:
-        php.expr_assignop_concat({depth: any}):
-          @ review.comment
-          php.expr_variable({depth: any}):
-            name: /(?i)SQL/
-        php.expr_assign({depth: any}):
-          @ review.comment
-          php.expr_variable({depth: any}):
-            name: /(?i)SQL/
-          php.expr_binaryop_concat({depth: any})
+      php.file({depth: any}):
+        any_of:
+          php.expr_assignop_concat({depth: any}):
+            @ review.comment
+            php.expr_variable({depth: any}):
+              name: /(?i)SQL/
+          php.expr_assign({depth: any}):
+            @ review.comment
+            php.expr_variable({depth: any}):
+              name: /(?i)SQL/
+            php.expr_binaryop_concat({depth: any})

--- a/tenets/codelingo/php/sql-concats/.lingo
+++ b/tenets/codelingo/php/sql-concats/.lingo
@@ -6,8 +6,13 @@ tenets:
         comments: SQL query strings shouldnt be concatenated as these are susceptible to SQL injection
     query: |
       import codelingo/ast/php
-      php.expr_assign({depth: any}):
-        @ review.comment
-        php.expr_variable({depth: any}):
-          name: /.*SQL*/
-        php.expr_binaryop_concat({depth: any})
+      any_of:
+        php.expr_assignop_concat({depth: any}):
+          @ review.comment
+          php.expr_variable({depth: any}):
+            name: /(?i)SQL/
+        php.expr_assign({depth: any}):
+          @ review.comment
+          php.expr_variable({depth: any}):
+            name: /(?i)SQL/
+          php.expr_binaryop_concat({depth: any})

--- a/tenets/codelingo/php/sql-concats/.lingo
+++ b/tenets/codelingo/php/sql-concats/.lingo
@@ -1,0 +1,13 @@
+tenets:
+  - name: sql-concats
+    doc: Find all variable name ending in SQL that contain string concatenations.
+    bots:
+      codelingo/review:
+        comments: SQL query strings shouldnt be concatenated as these are susceptible to SQL injection
+    query: |
+      import codelingo/ast/php
+      php.expr_assign({depth: any}):
+        @ review.comment
+        php.expr_variable({depth: any}):
+          name: /.*SQL*/
+        php.expr_binaryop_concat({depth: any})

--- a/tenets/codelingo/php/sql-concats/example.php
+++ b/tenets/codelingo/php/sql-concats/example.php
@@ -3,9 +3,15 @@ function ExecuteSQL ($query) {
 	return "SQL result\n";
 }
 function Main() {
-	$userNamesSQL = "SELECT name FROM Users";
+	$userTable = "USERS";
+	$userNamesSQL = "SELECT name FROM " . $userTable; // ISSUE
 	$userNames = ExecuteSQL($userNamesSQL);
 	print $userNames;
+
+	$sql = "SELECT cost FROM ";
+	$sql .= "PRODUCTS"; // ISSUE
+	$products = ExecuteSQL($sql);
+	print $$products;
 }
 Main();
 php>

--- a/tenets/codelingo/php/sql-concats/example.php
+++ b/tenets/codelingo/php/sql-concats/example.php
@@ -1,0 +1,11 @@
+<?php
+function ExecuteSQL ($query) {
+	return "SQL result\n";
+}
+function Main() {
+	$userNamesSQL = "SELECT name FROM Users";
+	$userNames = ExecuteSQL($userNamesSQL);
+	print $userNames;
+}
+Main();
+php>

--- a/tenets/codelingo/php/sql-concats/ideal-solution.lingo
+++ b/tenets/codelingo/php/sql-concats/ideal-solution.lingo
@@ -1,0 +1,62 @@
+tenets:
+  - name: sql-concats
+    doc: Find all variable name ending in SQL that contain string concatenations.
+    bots:
+      codelingo/review:
+        comments: SQL query strings shouldnt be concatenated as these are susceptible to SQL injection
+    query: |
+      import codelingo/ast/php
+
+      # Find values from an http request
+      php.stmt_classmethod({depth: any}):
+        php.expr_assign:
+          php.expr_variable:
+            name: $httpVariable
+          php.expr_methodcall({depth: any}): # PHP surprisingly appears to have objects hanging off method calls
+            name: "get"
+            php.expr_propertyfetch:
+              name: "request"
+
+        # Find method that concatenates the http value into a string
+        php.calls({depth: any}):
+          php.arg:
+            name: $httpVariable
+          # Recurse along method call chain to find concatenation method
+          # TODO: validate that the $httpVariable is passed along call chain
+          php.calls({depth: any, follow: callgraph}):
+            php.stmt_classmethod({depth: any}):
+              php.param:
+                # find variables whose value can be affected by the parameter
+                php.may_assign_to:
+                  name: $httpArg
+              any_of:
+                php.expr_assignop_concat({depth: any}):
+                  @ review.comment
+                  php.expr_variable({depth: any}):
+                    name: $sqlStatement
+                    php.expr_variable({depth: any}):
+                      name: $httpArg
+                php.expr_assign({depth: any}):
+                  @ review.comment
+                  php.expr_variable({depth: any}):
+                    name: $sqlStatement
+                    php.expr_variable({depth: any}):
+                      name: $httpArg
+                  php.expr_binaryop_concat({depth: any})
+
+              # Check that $sqlStatement is passed to a database method
+              @ review.comment
+              php.calls({depth: any}):
+                php.arg:
+                  php.expr_variable:
+                    name: $sqlStatement
+                # TODO: validate that the $sqlStatement is passed along call chain
+                php.calls({depth: any, follow: callgraph}):
+                  is: $dbmethod
+
+      # Collect methods that access the database
+      php.stmt_namespace:
+        php.name: "Util\DB"
+        php.stmt_class:
+          name: Model
+          php.stmt_classmethod: $dbmethod


### PR DESCRIPTION
Update and validate https://github.com/codelingo/hub/pull/27

The .lingo file finds SQL injections my finding variables named `/.*sql.*/i` in string concatenations. The ideal-solution.lingo file demonstrates a tenet that will follow a variable from an http handler, through a concatenation, to the database, with the caveats that we can't follow the callgraph yet, following the callgraph doesn't guarantee that the same variable was passed through each call, and we don't have [fact variables](https://trello.com/c/ILBiZyIW/1230-5-support-fact-variables) (nice to have).