### PR TITLE
Remove * from tenet name.

### DIFF
--- a/tenets/cacophony/default/no-fmt-print/.lingo
+++ b/tenets/cacophony/default/no-fmt-print/.lingo
@@ -1,5 +1,5 @@
 tenets:
-  - name: no-fmt-print*
+  - name: no-fmt-printx
     doc: |
       Find uses fmt.Print* (eg. Print, Println, Printf).
 


### PR DESCRIPTION
Tenet names must match `([a-z](?:[-_]?[a-z0-9]*)*)` or they will error out. Though `no-fmt-print*` is admittedly a more descriptive name than `no-fmt-printx`.

Should have been caught in CI https://trello.com/c/Hukxhr5T/826-ci-test-cd-to-hub-tenets-and-run-review-flow-check-that-nothing-fails